### PR TITLE
Adds support for reloading aliases

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-autoreload "0.1.1"
+(defproject komcrad/lein-autoreload "0.1.2-SNAPSHOT"
   :description "When running the repl, reload every time a file is saved."
-  :url "https://github.com/skilbjo/lein-autoreload"
+  :url "https://github.com/komcrad/lein-autoreload"
   :license {:name "MIT"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [


### PR DESCRIPTION
Previously, if you had aliased a namespace and lein-autoreload reloaded your ns, your alias would not update.
Example.
You have an alias foo that pointed to package.package.foo. You add the function hello to package.package.foo. You save the file. lein-autoreload reloads the file.
Now, you can call (package.package.foo/hello), but you cannot call (foo/hello)
This PR works around that. When files are reloaded, the aliases for *ns* are refreshed as well.
